### PR TITLE
Fix feed manager external ID handling

### DIFF
--- a/aio_geojson_client/feed_manager.py
+++ b/aio_geojson_client/feed_manager.py
@@ -48,7 +48,8 @@ class FeedManagerBase:
             # Record current time of update.
             self._last_update_successful = self._last_update
             # For entity management the external ids from the feed are used.
-            feed_external_ids = set(self.feed_entries)
+            feed_external_ids = set([entry.external_id
+                                     for entry in feed_entries])
             count_removed = await self._update_feed_remove_entries(
                 feed_external_ids)
             count_updated = await self._update_feed_update_entries(


### PR DESCRIPTION
Use the external ids from the current feed result, not from the previously stored entries.