### PR TITLE
Bump black to 22.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.12.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
for Python 3.11 support