### PR TITLE
Improve JSON parsing error handling

### DIFF
--- a/aio_geojson_client/feed.py
+++ b/aio_geojson_client/feed.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
-from json import JSONDecodeError
 from typing import Callable, Dict, Generic, List, Optional, Tuple
 
 import aiohttp
@@ -133,9 +132,9 @@ class GeoJsonFeed(Generic[T_FEED_ENTRY], ABC):
                         "Fetching data from %s failed with %s", self._url, client_error
                     )
                     return UPDATE_ERROR, None
-                except JSONDecodeError as decode_ex:
+                except ValueError as value_ex:
                     _LOGGER.warning(
-                        "Unable to parse JSON from %s: %s", self._url, decode_ex
+                        "Unable to parse JSON from %s: %s", self._url, value_ex
                     )
                     return UPDATE_ERROR, None
         except client_exceptions.ClientError as client_error:


### PR DESCRIPTION
Currently, JSON parsing already takes care of any error occurring when using Python's built-in decoder. However, when you happen to have the `simplejson` library installed, JSON parsing errors are not properly caught and handled. This PR changes this and catches errors occurring when using either of the decoders.